### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Examples:
 ##### Example rules message for RPSLS
 
 ```
-Rules for the Lizard-Spock Espansion of Rock Paper Scissors:
+Rules for the Lizard-Spock Expansion of Rock Paper Scissors:
 
   - Scissors CUTS Paper
   - Paper COVERS Rock


### PR DESCRIPTION
Fixed typo in the RPSLS rules which could cause autograder not passing.